### PR TITLE
Set a tag color based on apple tag emoji

### DIFF
--- a/web/components/bookmark/bookmark-view.css
+++ b/web/components/bookmark/bookmark-view.css
@@ -28,7 +28,6 @@
   font-size: 0.8em;
 }
 
-.bc-tags-display a,
 .bc-date a,
 .bc-bookmark-url-display a {
   color: var(--accent-foreground);
@@ -36,4 +35,5 @@
 
 .bc-tags-display a {
   margin-right: 5px;
+  color:  var(--bc-tags-color);
 }

--- a/web/document.css
+++ b/web/document.css
@@ -3,6 +3,8 @@
 :root {
   --body-padding: 2px;
   --small-font-size: 13px;
+
+  --bc-tags-color: hsla(24, 73%, 63%, 1);
 }
 
 /* style.css site specific stuff */


### PR DESCRIPTION
Sets up a little contrast around the tag links. It's based on an hsla adjustment of the tags emoji so it fits within the cardboard 'tag' theme.