### PR TITLE
Optimistic save

### DIFF
--- a/web/lib/diff-bookmark.js
+++ b/web/lib/diff-bookmark.js
@@ -9,10 +9,6 @@ function equalSet (a, b) {
 }
 
 export function diffBookmark (oldBookmark, newBookmark) {
-  console.log({
-    oldBookmark,
-    newBookmark
-  })
   const bookmarkDiff = {}
   for (const [key, newValue] of Object.entries(newBookmark)) {
     const oldValue = oldBookmark[key]


### PR DESCRIPTION
Implement optimistic save. Existing bookmarks are unmodified, but the API has an update query you can add to the request that will redirect you to the update endpoint which accepts the same body format.

Closes https://github.com/hifiwi-fi/breadcrum.net/issues/248