### PR TITLE
Switch to unified route on yt-dlp-api (Restore Youtube extraction)

### DIFF
--- a/packages/resources/episodes/yt-dlp-api-client.js
+++ b/packages/resources/episodes/yt-dlp-api-client.js
@@ -25,7 +25,7 @@ export async function getYTDLPMetadata ({
 
   requestURL.searchParams.set('url', url)
   requestURL.searchParams.set('format', formatOpts)
-  requestURL.pathname = 'info'
+  requestURL.pathname = 'unified'
 
   const response = await undiciRequest(requestURL, {
     headers: {
@@ -47,19 +47,8 @@ export async function getYTDLPMetadata ({
   return metadata
 }
 
-const videoFormat = 'best[ext=mp4]/best[ext=mov]/mp4/mov'
-const audioFormat = 'ba[ext=m4a]/ba[ext=mp4]/ba[ext=mp3]/mp3/m4a'
-
 function getFormatArg (medium) {
   if (!['video', 'audio'].includes(medium)) throw new Error('format must be video or audio')
 
-  const formatOpts = medium === 'video'
-    ? [videoFormat, audioFormat].join('/')
-    : medium === 'audio'
-      ? [audioFormat, videoFormat].join('/')
-      : null
-
-  if (!formatOpts) throw new Error('No format options generated. Please report this bug')
-
-  return formatOpts
+  return medium
 }

--- a/packages/worker/workers/episode-worker/index.js
+++ b/packages/worker/workers/episode-worker/index.js
@@ -77,7 +77,7 @@ export function makeEpisodeWorker ({ fastify }) {
           videoData.push(SQL`title = ${metadata.title.trim().substring(0, 255)}`)
         }
         if ('ext' in metadata) videoData.push(SQL`ext = ${metadata.ext}`)
-        if ('_type' in metadata) videoData.push(SQL`src_type = ${resolveType(metadata)}`)
+        if ('ext' in metadata) videoData.push(SQL`src_type = ${resolveType(metadata)}`)
         if ('description' in metadata) {
           videoData.push(SQL`text_content = ${metadata.description}`)
         }


### PR DESCRIPTION
Use the new unified routes on yt-dlp-api. This restores video support on YouTube.