### PR TITLE
Fix skipped view transition Sentry noise

### DIFF
--- a/packages/web/client/globals/global.client.js
+++ b/packages/web/client/globals/global.client.js
@@ -7,6 +7,7 @@ import 'fragmentions'
 import { html } from 'htm/preact'
 import { render } from 'preact'
 import { Header } from '../components/header/index.js'
+import { isSkippedViewTransitionAbortError } from './sentry-filters.js'
 
 const sentryDsn = process.env['SENTRY_BROWSER_DSN']
 
@@ -18,6 +19,11 @@ if (sentryDsn) {
     dataCollection: {
       // userInfo: false,
       // httpBodies: [],
+    },
+    beforeSend (event, hint) {
+      if (isSkippedViewTransitionAbortError(event, hint)) return null
+
+      return event
     },
   })
 }

--- a/packages/web/client/globals/global.css
+++ b/packages/web/client/globals/global.css
@@ -5,8 +5,10 @@
 @import "../components/header";
 @import "../components/footer";
 
-@view-transition {
-  navigation: auto;
+@media (prefers-reduced-motion: no-preference) {
+  @view-transition {
+    navigation: auto;
+  }
 }
 
 :root {

--- a/packages/web/client/globals/sentry-filters.js
+++ b/packages/web/client/globals/sentry-filters.js
@@ -1,0 +1,63 @@
+/// <reference lib="dom" />
+
+const skippedViewTransitionMessage = 'Skipping view transition because skipTransition() was called.'
+
+/**
+ * @typedef {Object} SentryExceptionValue
+ * @property {string} [type]
+ * @property {string} [value]
+ */
+
+/**
+ * @typedef {Object} SentryEvent
+ * @property {{ values?: SentryExceptionValue[] }} [exception]
+ */
+
+/**
+ * @typedef {Object} SentryEventHint
+ * @property {unknown} [originalException]
+ * @property {unknown} [syntheticException]
+ */
+
+/**
+ * Safari can reject internal View Transition promises when a transition is
+ * intentionally skipped during page restoration/navigation. This is browser
+ * noise rather than an application failure.
+ *
+ * @param {SentryEvent} event
+ * @param {SentryEventHint} [hint]
+ * @returns {boolean}
+ */
+export function isSkippedViewTransitionAbortError (event, hint = {}) {
+  if (isSkippedViewTransitionAbortException(hint.originalException)) return true
+  if (isSkippedViewTransitionAbortException(hint.syntheticException)) return true
+
+  return event.exception?.values?.some(value => (
+    value.type === 'AbortError' &&
+    typeof value.value === 'string' &&
+    isSkippedViewTransitionMessage(value.value)
+  )) === true
+}
+
+/**
+ * @param {unknown} exception
+ * @returns {boolean}
+ */
+function isSkippedViewTransitionAbortException (exception) {
+  if (!exception || typeof exception !== 'object') return false
+
+  const errorLike = /** @type {{ name?: unknown, message?: unknown }} */ (exception)
+
+  return errorLike.name === 'AbortError' &&
+    typeof errorLike.message === 'string' &&
+    isSkippedViewTransitionMessage(errorLike.message)
+}
+
+/**
+ * @param {string} message
+ * @returns {boolean}
+ */
+function isSkippedViewTransitionMessage (message) {
+  return message === skippedViewTransitionMessage ||
+    message === `AbortError: ${skippedViewTransitionMessage}`
+}

--- a/packages/web/client/globals/sentry-filters.test.js
+++ b/packages/web/client/globals/sentry-filters.test.js
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict'
+import { suite, test } from 'node:test'
+import { isSkippedViewTransitionAbortError } from './sentry-filters.js'
+
+suite('Sentry filters', () => {
+  test('filters skipped View Transition AbortErrors from Sentry event exceptions', () => {
+    assert.equal(isSkippedViewTransitionAbortError({
+      exception: {
+        values: [{
+          type: 'AbortError',
+          value: 'Skipping view transition because skipTransition() was called.',
+        }],
+      },
+    }), true)
+  })
+
+  test('filters skipped View Transition AbortErrors from Sentry hint exceptions', () => {
+    assert.equal(isSkippedViewTransitionAbortError({}, {
+      originalException: new DOMException(
+        'Skipping view transition because skipTransition() was called.',
+        'AbortError'
+      ),
+    }), true)
+  })
+
+  test('keeps unrelated AbortErrors', () => {
+    assert.equal(isSkippedViewTransitionAbortError({
+      exception: {
+        values: [{
+          type: 'AbortError',
+          value: 'The operation was aborted.',
+        }],
+      },
+    }), false)
+  })
+
+  test('keeps non-AbortErrors with the same message', () => {
+    assert.equal(isSkippedViewTransitionAbortError({
+      exception: {
+        values: [{
+          type: 'Error',
+          value: 'Skipping view transition because skipTransition() was called.',
+        }],
+      },
+    }), false)
+  })
+})


### PR DESCRIPTION
## Summary

- Gate automatic cross-document View Transitions behind `prefers-reduced-motion: no-preference`
- Add a targeted Sentry `beforeSend` filter for Safari's skipped View Transition `AbortError`
- Add tests for the Sentry filter so unrelated errors continue to report

## Validation

- `node --test packages/web/client/globals/sentry-filters.test.js`
- `pnpm --filter @breadcrum/web test:eslint`
- `pnpm --filter @breadcrum/web test:tsc`

Fixes BC-CLIENT-2