### PR TITLE
Align custom styles with mine.css v11

### DIFF
--- a/packages/web/client/admin/flags/style.css
+++ b/packages/web/client/admin/flags/style.css
@@ -7,10 +7,7 @@
 }
 
 .bc-admin-flags fieldset {
-  border: 1px solid var(--accent-midground);
-  border-radius: 6px;
   padding: 1rem 1.25rem;
-  background: var(--accent-background);
 }
 
 .bc-admin-flags-legend {

--- a/packages/web/client/components/article-header/index.css
+++ b/packages/web/client/components/article-header/index.css
@@ -26,7 +26,11 @@
   }
 
   & .author-info img {
-    border: 1px solid rgba(0,0,0,.1);
+    border: 1px solid color-mix(
+      in srgb,
+      var(--accent-midground) 70%,
+      var(--background)
+    );
     border-radius: 50%;
     padding: 4px;
   }

--- a/packages/web/client/components/cors-media/cors-media.css
+++ b/packages/web/client/components/cors-media/cors-media.css
@@ -1,11 +1,5 @@
-.bc-cors-video,
-.bc-cors-audio {
-  width: 100%;
-}
-
 .bc-cors-video {
-  border-radius: 10px;
-  background-color: var(--accent-background);
+  width: 100%;
   overflow: hidden;
 }
 
@@ -17,15 +11,16 @@
   width: 100%;
   aspect-ratio: 16 / 9;
   background: var(--accent-background);
-  border: 1px solid var(--accent-foreground);
-  border-radius: 5px;
+  border: 1px solid var(--control-border);
+  border-radius: 7px;
+  box-shadow: var(--surface-shadow);
   cursor: pointer;
   overflow: hidden;
   padding: 0;
 }
 
 .bc-cors-media-activate:hover {
-  border-color: var(--link-color);
+  border-color: var(--link-text);
 }
 
 .bc-cors-media-activate-thumb {

--- a/packages/web/client/components/episode/episode-view.css
+++ b/packages/web/client/components/episode/episode-view.css
@@ -38,15 +38,7 @@
   color: var(--accent-foreground);
 }
 
-.bc-episode-video-preview,
-.bc-episode-audio-preview {
-  width: 100%;
-}
 
-.bc-episode-video-preview {
-  background-color: var(--accent-background);
-  border-radius: 5px;
-}
 
 .bc-episode-embed {
   margin: 8px 0;
@@ -63,6 +55,8 @@
   height: auto;
   aspect-ratio: var(--bc-embed-aspect);
   border: 0;
+  background-color: transparent;
+  box-shadow: none;
 }
 
 .bc-episode-embed--soundcloud .bc-episode-embed-html iframe {
@@ -79,8 +73,9 @@
   width: 100%;
   aspect-ratio: var(--bc-embed-aspect, 16 / 9);
   background: var(--accent-background);
-  border: 2px solid var(--accent-midground);
-  border-radius: 5px;
+  border: 1px solid var(--control-border);
+  border-radius: 7px;
+  box-shadow: var(--surface-shadow);
   cursor: pointer;
   overflow: hidden;
   padding: 0;

--- a/packages/web/client/globals/document.css
+++ b/packages/web/client/globals/document.css
@@ -55,22 +55,18 @@
   }
 }
 
-.bc-header {
-}
-
 .bc-main {
   flex-grow: 1;
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: 46em;
+  max-width: 56em;
   margin: 0 auto;
   padding-top: 0;
-  padding-left: 1em;
-  padding-right: 1em;
+  padding-left: max(1em, env(safe-area-inset-left));
+  padding-right: max(1em, env(safe-area-inset-right));
   padding-bottom: 1em;
-  overflow: hidden;
-  /* word-wrap: break-word; */
+  overflow-wrap: break-word;
 }
 
 /* .bc-main > *:first-child { margin-top: 0 !important; } */

--- a/packages/web/client/globals/document.css
+++ b/packages/web/client/globals/document.css
@@ -60,6 +60,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  /* TODO: Revisit the wider measure after evaluating it across production pages. */
   max-width: 56em;
   margin: 0 auto;
   padding-top: 0;

--- a/packages/web/client/style.css
+++ b/packages/web/client/style.css
@@ -1,7 +1,7 @@
 @import './components/badge/badge.css';
 
 .bc-main {
-	max-width: 55em;
+	max-width: 56em;
 }
 
 .bc-marketing {


### PR DESCRIPTION
## Summary

- update the custom page layout to match mine.css v11 width, overflow, wrapping, and safe-area behavior
- align media activation controls and image borders with the v11 border and surface tokens
- remove stale media rules and make provider embeds borderless and shadowless while retaining rounded corners
- let admin fieldsets use the complete mine.css v11 surface styling

## Validation

- `pnpm --filter @breadcrum/web run test:eslint --fix`
- `pnpm --filter @breadcrum/web build`
- editor diagnostics report no errors or warnings
- `git diff --check`
- `pnpm --filter @breadcrum/web test` progressed without a reported failure but exceeded the 120-second command timeout before printing its final summary

## Browser review

- inspect direct video and audio previews in light and dark modes
- inspect click-to-load media controls and keyboard focus states
- verify YouTube and SoundCloud embed sizing and rounded corners
- check wide and narrow layouts for unexpected overflow after removing main-content clipping