### PR TITLE
Redact sensitive URL data and deduplicate request logs

### DIFF
--- a/packages/resources/fastify-common/logger-options.js
+++ b/packages/resources/fastify-common/logger-options.js
@@ -11,12 +11,71 @@ const PinoLevelToSeverityLookup = /** @type {const} */ ({
   fatal: 'CRITICAL',
 })
 
+const urlLogPaths = [
+  'sourceUrl',
+  'url',
+  'req.url',
+  'err.message',
+  'err.stack',
+  'err.description',
+  'err.cause.message',
+  'err.cause.stack',
+  'ytDlpDescription',
+]
+
+/**
+ * Remove URL data that can contain credentials or signatures while retaining
+ * enough stable information to identify the source.
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+function redactUrlData (value) {
+  if (typeof value !== 'string') return '[Redacted]'
+
+  if (value.startsWith('/') || /^[a-z][a-z\d+.-]*:\/\//i.test(value)) {
+    return sanitizeUrl(value)
+  }
+
+  return value.replace(/https?:\/\/[^\s]+/gi, url => sanitizeUrl(url))
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function sanitizeUrl (value) {
+  try {
+    const isRelative = value.startsWith('/')
+    const url = new URL(value, 'https://redacted.invalid')
+    const videoId = isYouTubeWatchUrl(url) ? url.searchParams.get('v') : null
+
+    url.username = ''
+    url.password = ''
+    url.search = ''
+    url.hash = ''
+    if (videoId) url.searchParams.set('v', videoId)
+
+    return isRelative ? `${url.pathname}${url.search}` : url.toString()
+  } catch {
+    return '[Redacted]'
+  }
+}
+
+/**
+ * @param {URL} url
+ * @returns {boolean}
+ */
+function isYouTubeWatchUrl (url) {
+  return /(^|\.)youtube\.com$/i.test(url.hostname) && url.pathname === '/watch'
+}
+
 /**
  * @typedef {Object} LoggerOptions
  * @property {() => { service: string }} mixin
  * @property {string} messageKey
  * @property {Object} formatters
  * @property {(label: string, number: number) => { level: string, levelN: number }} formatters.level
+ * @property {{paths: string[], censor: (value: unknown) => unknown}} redact
  */
 
 /**
@@ -33,6 +92,10 @@ export function createLoggerOptions ({ serviceName }) {
       }
     },
     messageKey: 'message',
+    redact: {
+      paths: urlLogPaths,
+      censor: redactUrlData,
+    },
     formatters: {
       level (/** @type{string} */label, /** @type{number} */number) {
         return {

--- a/packages/resources/fastify-common/logger-options.js
+++ b/packages/resources/fastify-common/logger-options.js
@@ -30,6 +30,7 @@ const urlLogPaths = [
  * @returns {unknown}
  */
 function redactUrlData (value) {
+  if (value == null) return value
   if (typeof value !== 'string') return '[Redacted]'
 
   if (value.startsWith('/') || /^[a-z][a-z\d+.-]*:\/\//i.test(value)) {

--- a/packages/resources/fastify-common/logger-options.test.js
+++ b/packages/resources/fastify-common/logger-options.test.js
@@ -13,6 +13,28 @@ test('createLoggerOptions returns valid logger configuration', () => {
   assert.equal(typeof loggerOptions.formatters.level, 'function', 'Level formatter should be a function')
 })
 
+test('redacts sensitive URL data while preserving YouTube video IDs', () => {
+  const loggerOptions = createLoggerOptions({ serviceName: 'test-service' })
+  const censor = loggerOptions.redact.censor
+
+  assert.equal(
+    censor('https://user:password@cdn.example.com/audio.mp3?Signature=secret#token'),
+    'https://cdn.example.com/audio.mp3'
+  )
+  assert.equal(
+    censor('https://www.youtube.com/watch?v=abc123&si=secret'),
+    'https://www.youtube.com/watch?v=abc123'
+  )
+  assert.equal(
+    censor('/unified?url=https%3A%2F%2Fcdn.example.com%2Fa.mp3%3FSignature%3Dsecret'),
+    '/unified'
+  )
+  assert.equal(
+    censor('Unable to download https://cdn.example.com/audio.mp3?Signature=secret HTTP 403'),
+    'Unable to download https://cdn.example.com/audio.mp3 HTTP 403'
+  )
+})
+
 test('mixin returns correct service name', () => {
   const serviceName = 'bc-web'
   const loggerOptions = createLoggerOptions({ serviceName })

--- a/packages/resources/fastify-common/logger-options.test.js
+++ b/packages/resources/fastify-common/logger-options.test.js
@@ -17,6 +17,9 @@ test('redacts sensitive URL data while preserving YouTube video IDs', () => {
   const loggerOptions = createLoggerOptions({ serviceName: 'test-service' })
   const censor = loggerOptions.redact.censor
 
+  assert.equal(censor(null), null)
+  assert.equal(censor(undefined), undefined)
+  assert.equal(censor({ query: 'secret' }), '[Redacted]')
   assert.equal(
     censor('https://user:password@cdn.example.com/audio.mp3?Signature=secret#token'),
     'https://cdn.example.com/audio.mp3'

--- a/packages/web/routes/api/feeds/_feed/episode/_episode/routes.js
+++ b/packages/web/routes/api/feeds/_feed/episode/_episode/routes.js
@@ -53,12 +53,13 @@ export default async function podcastFeedsRoutes (fastify, _opts) {
     async function episodeHandler (request, reply) {
       const feedTokenUser = /** @type {FeedAuthRequest} */ (request).feedTokenUser
       const userId = feedTokenUser?.userId ?? request?.user?.id
-      const username = feedTokenUser?.username ?? request?.user?.username
       if (!userId) return reply.unauthorized('Missing authenticated feed userId')
 
       const { feed: feedId, episode: episodeId } = request.params
       const requestLogger = /** @type {FastifyBaseLogger & {setBindings?: (bindings: Record<string, unknown>) => void}} */ (request.log)
-      requestLogger.setBindings?.({ userId, username, feedId, episodeId })
+      requestLogger.setBindings?.(feedTokenUser
+        ? { episodeId }
+        : { feedId, episodeId })
 
       const episodeQuery = SQL`
           select
@@ -111,10 +112,6 @@ export default async function podcastFeedsRoutes (fastify, _opts) {
       const cachedUrl = await fastify.urlCache.get(cacheKey)
       const clientGeoip = fastify.geoip?.lookup(request.ip)
       const mediaRequestLog = {
-        userId,
-        username,
-        feedId,
-        episodeId,
         sourceUrl: episode.src_url,
         medium: episode.medium,
         authenticationType: feedTokenUser ? 'feed-token' : 'jwt',

--- a/packages/web/routes/api/feeds/_feed/episode/_episode/routes.js
+++ b/packages/web/routes/api/feeds/_feed/episode/_episode/routes.js
@@ -41,7 +41,7 @@ export default async function podcastFeedsRoutes (fastify, _opts) {
               type: 'string',
               format: 'uuid',
             },
-            episodes: {
+            episode: {
               type: 'string',
               format: 'uuid',
             },

--- a/packages/web/routes/api/feeds/_feed/episode/_episode/routes.js
+++ b/packages/web/routes/api/feeds/_feed/episode/_episode/routes.js
@@ -36,6 +36,7 @@ export default async function podcastFeedsRoutes (fastify, _opts) {
         tags: ['feeds', 'episodes'],
         params: {
           type: 'object',
+          additionalProperties: false,
           properties: {
             feed: {
               type: 'string',


### PR DESCRIPTION
## Summary

- Use Pino redaction to remove credentials, fragments, and query parameters from logged URLs.
- Preserve the YouTube video ID when sanitizing YouTube watch URLs.
- Sanitize incoming request URLs and URLs embedded in serialized errors.
- Preserve nullish values during redaction while censoring unexpected non-string values.
- Avoid repeating user, feed, and episode context already bound to the request logger.
- Correct the episode route parameter schema so the actual episode parameter is validated as a UUID.

The logging changes do not modify source URLs used for extraction, caching, or redirects.

The route schema correction is a functional validation change: malformed episode IDs now fail Fastify UUID validation instead of reaching the database as unconstrained additional parameters.

## Testing

- pnpm test
- Verified Pino and Fastify serialization with signed source URLs, request URLs, error messages, null values, and undefined values.
- Verified the previous route schema accepted a malformed episode UUID before correcting the schema key.