### PR TITLE
Use structured logging for embed resolution

### DIFF
--- a/packages/resources/bookmarks/normalize-url.js
+++ b/packages/resources/bookmarks/normalize-url.js
@@ -14,7 +14,7 @@ import { isNotSSRF } from '../urls/ssrf-check.js'
  * @property {number} [maxRedirects=5] - Max redirect hops when expanding short URLs.
  * @property {number} [timeoutMs=5000] - Timeout per request when expanding short URLs.
  * @property {NormalizeUrlCache} [cache] - Optional cache for shortener expansions.
- * @property {FastifyBaseLogger} [logger] - Request logger for correlated validation failures.
+ * @property {FastifyBaseLogger} logger - Request logger for correlated validation failures.
  */
 
 const SHORTENER_CACHE_TTL_MS = 5 * 60 * 1000
@@ -91,10 +91,10 @@ const X_HOSTS = new Set([
  * Normalizes a URL object by modifying its host property if necessary.
  *
  * @param {URL} url - The URL string to be normalized.
- * @param {NormalizeUrlOptions} [options] - Optional normalization configuration.
+ * @param {NormalizeUrlOptions} options - Normalization configuration and request logger.
  * @returns {Promise<URL>} An object containing the normalized URL string.
  */
-export async function normalizeURL (url, options = {}) {
+export async function normalizeURL (url, options) {
   const { followShorteners = true, maxRedirects = 5, timeoutMs = 5000, cache, logger } = options
   let workingUrl = new URL(url.toString())
 
@@ -253,7 +253,7 @@ function sortQueryParams (url) {
 
 /**
  * @param {URL} url
- * @param {{ maxRedirects: number, timeoutMs: number, cache: NormalizeUrlCache | undefined, logger: FastifyBaseLogger | undefined }} options
+ * @param {{ maxRedirects: number, timeoutMs: number, cache: NormalizeUrlCache | undefined, logger: FastifyBaseLogger }} options
  * @returns {Promise<URL>}
  */
 async function expandShortUrl (url, options) {

--- a/packages/resources/bookmarks/normalize-url.js
+++ b/packages/resources/bookmarks/normalize-url.js
@@ -1,5 +1,7 @@
 import { isNotSSRF } from '../urls/ssrf-check.js'
 
+/** @import { FastifyBaseLogger } from 'fastify' */
+
 /**
  * @typedef {object} NormalizeUrlCache
  * @property {(key: string) => Promise<unknown>} get
@@ -12,6 +14,7 @@ import { isNotSSRF } from '../urls/ssrf-check.js'
  * @property {number} [maxRedirects=5] - Max redirect hops when expanding short URLs.
  * @property {number} [timeoutMs=5000] - Timeout per request when expanding short URLs.
  * @property {NormalizeUrlCache} [cache] - Optional cache for shortener expansions.
+ * @property {FastifyBaseLogger} [logger] - Request logger for correlated validation failures.
  */
 
 const SHORTENER_CACHE_TTL_MS = 5 * 60 * 1000
@@ -92,15 +95,15 @@ const X_HOSTS = new Set([
  * @returns {Promise<URL>} An object containing the normalized URL string.
  */
 export async function normalizeURL (url, options = {}) {
-  const { followShorteners = true, maxRedirects = 5, timeoutMs = 5000, cache } = options
+  const { followShorteners = true, maxRedirects = 5, timeoutMs = 5000, cache, logger } = options
   let workingUrl = new URL(url.toString())
 
   sanitizeUrl(workingUrl)
 
   if (followShorteners && typeof fetch === 'function' && isShortenerHost(workingUrl.hostname)) {
     const expandOptions = cache
-      ? { maxRedirects, timeoutMs, cache }
-      : { maxRedirects, timeoutMs, cache: undefined }
+      ? { maxRedirects, timeoutMs, cache, logger }
+      : { maxRedirects, timeoutMs, cache: undefined, logger }
     workingUrl = await expandShortUrl(workingUrl, expandOptions)
     sanitizeUrl(workingUrl)
   }
@@ -250,7 +253,7 @@ function sortQueryParams (url) {
 
 /**
  * @param {URL} url
- * @param {{ maxRedirects: number, timeoutMs: number, cache: NormalizeUrlCache | undefined }} options
+ * @param {{ maxRedirects: number, timeoutMs: number, cache: NormalizeUrlCache | undefined, logger: FastifyBaseLogger | undefined }} options
  * @returns {Promise<URL>}
  */
 async function expandShortUrl (url, options) {
@@ -274,7 +277,7 @@ async function expandShortUrl (url, options) {
     if (!nextUrl || !isHttpProtocol(nextUrl.protocol) || visited.has(nextUrl.href)) break
 
     // SSRF protection: reject redirects to internal/private IPs using comprehensive DNS-based checks
-    const isSafe = await isNotSSRF(nextUrl.href)
+    const isSafe = await isNotSSRF(nextUrl.href, options.logger)
     if (!isSafe) break
 
     visited.add(nextUrl.href)

--- a/packages/resources/bookmarks/normalize-url.js
+++ b/packages/resources/bookmarks/normalize-url.js
@@ -101,9 +101,7 @@ export async function normalizeURL (url, options) {
   sanitizeUrl(workingUrl)
 
   if (followShorteners && typeof fetch === 'function' && isShortenerHost(workingUrl.hostname)) {
-    const expandOptions = cache
-      ? { maxRedirects, timeoutMs, cache, logger }
-      : { maxRedirects, timeoutMs, cache: undefined, logger }
+    const expandOptions = { maxRedirects, timeoutMs, cache, logger }
     workingUrl = await expandShortUrl(workingUrl, expandOptions)
     sanitizeUrl(workingUrl)
   }

--- a/packages/resources/bookmarks/normalize-url.test.js
+++ b/packages/resources/bookmarks/normalize-url.test.js
@@ -1,6 +1,23 @@
 import { equal, ok } from 'node:assert'
 import { test } from 'node:test'
-import { normalizeURL } from './normalize-url.js'
+import { normalizeURL as normalizeURLWithLogger } from './normalize-url.js'
+
+/**
+ * @import { FastifyBaseLogger } from 'fastify'
+ * @import { NormalizeUrlOptions } from './normalize-url.js'
+ */
+
+const logger = /** @type {FastifyBaseLogger} */ (/** @type {unknown} */ ({
+  warn () {},
+}))
+
+/**
+ * @param {URL} url
+ * @param {Omit<NormalizeUrlOptions, 'logger'>} options
+ */
+function normalizeURL (url, options) {
+  return normalizeURLWithLogger(url, { ...options, logger })
+}
 
 // YouTube normalization tests
 test('normalizeURL - youtube shorts normalize to watch', async () => {

--- a/packages/resources/fastify-common/otel-shutdown.js
+++ b/packages/resources/fastify-common/otel-shutdown.js
@@ -25,8 +25,11 @@ export function registerOtelShutdown (fastify) {
   fastify.addHook('onClose', async function shutdownOtel () {
     if (!otelSdk) return
 
+    const sdk = otelSdk
+    otelSdk = undefined
+
     try {
-      await otelSdk.shutdown()
+      await sdk.shutdown()
       fastify.log.info('OpenTelemetry SDK shut down successfully')
     } catch (err) {
       fastify.log.error({ err }, 'Error shutting down OpenTelemetry SDK')

--- a/packages/resources/fastify-common/otel-shutdown.js
+++ b/packages/resources/fastify-common/otel-shutdown.js
@@ -1,0 +1,35 @@
+/** @import { FastifyInstance } from 'fastify' */
+
+/**
+ * @typedef {object} OtelSdk
+ * @property {() => Promise<void>} shutdown
+ */
+
+/** @type {OtelSdk | undefined} */
+let otelSdk
+
+/**
+ * Make the SDK created by the process preload available to the Fastify lifecycle.
+ * Tests that do not preload OpenTelemetry leave this value undefined.
+ * @param {OtelSdk | undefined} sdk
+ */
+export function setOtelSdk (sdk) {
+  otelSdk = sdk
+}
+
+/**
+ * Shut down the preloaded OpenTelemetry SDK with the application logger.
+ * @param {FastifyInstance} fastify
+ */
+export function registerOtelShutdown (fastify) {
+  fastify.addHook('onClose', async function shutdownOtel () {
+    if (!otelSdk) return
+
+    try {
+      await otelSdk.shutdown()
+      fastify.log.info('OpenTelemetry SDK shut down successfully')
+    } catch (err) {
+      fastify.log.error({ err }, 'Error shutting down OpenTelemetry SDK')
+    }
+  })
+}

--- a/packages/resources/fastify-common/otel-shutdown.test.js
+++ b/packages/resources/fastify-common/otel-shutdown.test.js
@@ -1,0 +1,21 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import Fastify from 'fastify'
+import { registerOtelShutdown, setOtelSdk } from './otel-shutdown.js'
+
+test('registerOtelShutdown closes the preloaded SDK with Fastify', async () => {
+  let shutdownCalls = 0
+  setOtelSdk({
+    async shutdown () {
+      shutdownCalls++
+    },
+  })
+  const app = Fastify({ logger: false })
+  registerOtelShutdown(app)
+  await app.ready()
+
+  await app.close()
+  setOtelSdk(undefined)
+
+  assert.equal(shutdownCalls, 1)
+})

--- a/packages/resources/fastify-common/otel-shutdown.test.js
+++ b/packages/resources/fastify-common/otel-shutdown.test.js
@@ -15,7 +15,11 @@ test('registerOtelShutdown closes the preloaded SDK with Fastify', async () => {
   await app.ready()
 
   await app.close()
-  setOtelSdk(undefined)
+
+  const secondApp = Fastify({ logger: false })
+  registerOtelShutdown(secondApp)
+  await secondApp.ready()
+  await secondApp.close()
 
   assert.equal(shutdownCalls, 1)
 })

--- a/packages/resources/urls/ssrf-check.js
+++ b/packages/resources/urls/ssrf-check.js
@@ -96,7 +96,7 @@ export async function isNotSSRF (urlString, logger) {
     return true // Passed all checks, URL is safe
   } catch (err) {
     const workingError = err instanceof Error ? err : new Error('Unknown Error Type', { cause: err })
-    logger?.warn({ err: workingError }, 'URL failed SSRF validation')
+    logger.warn({ err: workingError }, 'URL failed SSRF validation')
     return false // Fail closed on error
   }
 }

--- a/packages/resources/urls/ssrf-check.js
+++ b/packages/resources/urls/ssrf-check.js
@@ -3,6 +3,8 @@
 import dns from 'node:dns/promises'
 import ipaddr from 'ipaddr.js'
 
+/** @import { FastifyBaseLogger } from 'fastify' */
+
 // List of blocked IP ranges
 const blockedIPRanges = [
   '127.0.0.0/8',   // Loopback
@@ -60,10 +62,11 @@ async function dnsRebindingCheck (hostname) {
 }
 
 /**
- * @param  {string}  urlString
+ * @param {string} urlString
+ * @param {FastifyBaseLogger | undefined} [logger]
  * @return {Promise<Boolean>}
  */
-export async function isNotSSRF (urlString) {
+export async function isNotSSRF (urlString, logger) {
   try {
     const url = new URL(urlString)
 
@@ -93,7 +96,7 @@ export async function isNotSSRF (urlString) {
     return true // Passed all checks, URL is safe
   } catch (err) {
     const workingError = err instanceof Error ? err : new Error('Unknown Error Type', { cause: err })
-    console.error('Error validating URL:', workingError.message)
+    logger?.warn({ err: workingError }, 'URL failed SSRF validation')
     return false // Fail closed on error
   }
 }

--- a/packages/resources/urls/ssrf-check.js
+++ b/packages/resources/urls/ssrf-check.js
@@ -64,7 +64,7 @@ async function dnsRebindingCheck (hostname) {
 /**
  * @param {string} urlString
  * @param {FastifyBaseLogger} logger
- * @return {Promise<Boolean>}
+ * @returns {Promise<boolean>}
  */
 export async function isNotSSRF (urlString, logger) {
   try {

--- a/packages/resources/urls/ssrf-check.js
+++ b/packages/resources/urls/ssrf-check.js
@@ -63,7 +63,7 @@ async function dnsRebindingCheck (hostname) {
 
 /**
  * @param {string} urlString
- * @param {FastifyBaseLogger | undefined} [logger]
+ * @param {FastifyBaseLogger} logger
  * @return {Promise<Boolean>}
  */
 export async function isNotSSRF (urlString, logger) {

--- a/packages/resources/urls/ssrf-check.test.js
+++ b/packages/resources/urls/ssrf-check.test.js
@@ -1,0 +1,22 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { isNotSSRF } from './ssrf-check.js'
+
+/** @import { FastifyBaseLogger } from 'fastify' */
+
+test('isNotSSRF logs validation failures through the provided logger', async () => {
+  /** @type {Array<{obj: unknown, message: string}>} */
+  const warnings = []
+  const logger = /** @type {FastifyBaseLogger} */ (/** @type {unknown} */ ({
+    warn (/** @type {unknown} */ obj, /** @type {string} */ message) {
+      warnings.push({ obj, message })
+    },
+  }))
+
+  const result = await isNotSSRF('not a URL', logger)
+
+  assert.equal(result, false)
+  assert.equal(warnings.length, 1)
+  assert.equal(warnings[0]?.message, 'URL failed SSRF validation')
+  assert.ok(warnings[0]?.obj && typeof warnings[0].obj === 'object')
+})

--- a/packages/web/otel.js
+++ b/packages/web/otel.js
@@ -6,6 +6,7 @@ import { FastifyOtelInstrumentation } from '@fastify/otel'
 import { RuntimeNodeInstrumentation } from '@opentelemetry/instrumentation-runtime-node'
 import { HostMetrics } from '@opentelemetry/host-metrics'
 import { metrics } from '@opentelemetry/api'
+import { setOtelSdk } from '@breadcrum/resources/fastify-common/otel-shutdown.js'
 
 const sentryDsn = process.env['SENTRY_DSN']
 const sentryEnvironment = process.env['SENTRY_ENVIRONMENT'] ?? process.env['ENV'] ?? process.env['NODE_ENV']
@@ -53,15 +54,7 @@ export const sdk = new NodeSDK({
 })
 
 sdk.start()
+setOtelSdk(sdk)
 
 // Must come after sdk.start() for getMeterProvider to return something
 new HostMetrics({ meterProvider: metrics.getMeterProvider() }).start()
-
-process.on('SIGTERM', () => {
-  sdk
-    .shutdown()
-    .then(
-      () => console.log('SDK shut down successfully'),
-      (err) => console.log(new Error('Error shutting down SDK', { cause: err }))
-    )
-})

--- a/packages/web/plugins/otel-shutdown.js
+++ b/packages/web/plugins/otel-shutdown.js
@@ -1,0 +1,8 @@
+import fp from 'fastify-plugin'
+import { registerOtelShutdown } from '@breadcrum/resources/fastify-common/otel-shutdown.js'
+
+export default fp(async function otelShutdown (fastify) {
+  registerOtelShutdown(fastify)
+}, {
+  name: 'otel-shutdown',
+})

--- a/packages/web/routes/api/admin/pgboss/pgboss-test-utils.js
+++ b/packages/web/routes/api/admin/pgboss/pgboss-test-utils.js
@@ -35,8 +35,7 @@ export async function createTestUser (app, t, options = {}) {
   }
 
   if (registerRes.statusCode !== 201) {
-    console.error('Registration failed:', registerRes.statusCode, registerRes.payload)
-    throw new Error(`Registration failed with status ${registerRes.statusCode}`)
+    throw new Error(`Registration failed with status ${registerRes.statusCode}: ${registerRes.payload}`)
   }
 
   const registerBody = JSON.parse(registerRes.payload)

--- a/packages/web/routes/api/bookmarks/_id/put-bookmark.js
+++ b/packages/web/routes/api/bookmarks/_id/put-bookmark.js
@@ -115,7 +115,7 @@ export async function putBookmark (fastify, _opts) {
           try {
             const submittedUrlString = bookmark.url
             const submittedUrl = new URL(submittedUrlString)
-            const normalizedUrl = await normalizeURL(submittedUrl, { cache: fastify.cache })
+            const normalizedUrl = await normalizeURL(submittedUrl, { cache: fastify.cache, logger: request.log })
             bookmark.url = normalizedUrl.toString()
             const originalUrl = normalizedUrl.toString() === submittedUrlString ? null : submittedUrlString
             updates.push(SQL`url = ${bookmark.url}`)
@@ -134,7 +134,7 @@ export async function putBookmark (fastify, _opts) {
           try {
             const normalizedArchiveUrls = await Promise.all(
               bookmark.archive_urls.map(async (archiveUrl) => {
-                const normalized = await normalizeURL(new URL(archiveUrl), { cache: fastify.cache })
+                const normalized = await normalizeURL(new URL(archiveUrl), { cache: fastify.cache, logger: request.log })
                 return normalized.toString()
               })
             )
@@ -148,7 +148,7 @@ export async function putBookmark (fastify, _opts) {
 
       if (shouldNormalize && bookmark.createEpisode?.url) {
         try {
-          const normalizedEpisodeUrl = await normalizeURL(new URL(bookmark.createEpisode.url), { cache: fastify.cache })
+          const normalizedEpisodeUrl = await normalizeURL(new URL(bookmark.createEpisode.url), { cache: fastify.cache, logger: request.log })
           bookmark.createEpisode.url = normalizedEpisodeUrl.toString()
         } catch (err) {
           return reply.badRequest('Invalid episode URL format')
@@ -157,7 +157,7 @@ export async function putBookmark (fastify, _opts) {
 
       if (shouldNormalize && bookmark.createArchive && typeof bookmark.createArchive === 'object' && bookmark.createArchive.url) {
         try {
-          const normalizedArchiveUrl = await normalizeURL(new URL(bookmark.createArchive.url), { cache: fastify.cache })
+          const normalizedArchiveUrl = await normalizeURL(new URL(bookmark.createArchive.url), { cache: fastify.cache, logger: request.log })
           bookmark.createArchive.url = normalizedArchiveUrl.toString()
         } catch (err) {
           return reply.badRequest('Invalid archive URL format')

--- a/packages/web/routes/api/bookmarks/get-bookmarks.js
+++ b/packages/web/routes/api/bookmarks/get-bookmarks.js
@@ -126,7 +126,7 @@ export async function getBookmarksHandler (fastify) {
       if (after) bookmarkParams.after = after
       if (url) {
         try {
-          const workingUrl = exactUrl ? url : (await normalizeURL(new URL(url), { cache: fastify.cache, followShorteners: false })).toString()
+          const workingUrl = exactUrl ? url : (await normalizeURL(new URL(url), { cache: fastify.cache, followShorteners: false, logger: request.log })).toString()
           bookmarkParams.url = workingUrl
         } catch (err) {
           return reply.badRequest('Invalid URL format')

--- a/packages/web/routes/api/bookmarks/put-bookmark-query.js
+++ b/packages/web/routes/api/bookmarks/put-bookmark-query.js
@@ -21,16 +21,16 @@ import { putTagsQuery } from '@breadcrum/resources/tags/put-tags-query.js'
  * @param {FastifyInstance} params.fastify - Fastify instance, used for logging and other utilities.
  * @param {PoolClient} params.pg - PostgreSQL connection or transaction client for executing the query.
  * @param {string} params.url - URL of the bookmark to be created.
- * @param {string} [params.title] - Title of the bookmark, defaults to the URL if not provided.
- * @param {string} [params.note] - Optional note associated with the bookmark.
- * @param {boolean} [params.toread=false] - Flag indicating if the bookmark is marked to read later.
- * @param {boolean} [params.sensitive=false] - Flag indicating if the bookmark is marked as sensitive.
+ * @param {string | undefined} [params.title] - Title of the bookmark, defaults to the URL if not provided.
+ * @param {string | undefined} [params.note] - Optional note associated with the bookmark.
+ * @param {boolean | undefined} [params.toread=false] - Flag indicating if the bookmark is marked to read later.
+ * @param {boolean | undefined} [params.sensitive=false] - Flag indicating if the bookmark is marked as sensitive.
  * @param {Array<string>} [params.archiveUrls=[]] - List of archived URLs, defaults to an empty array.
- * @param {string} [params.summary] - Optional summary of the bookmark.
+ * @param {string | undefined} [params.summary] - Optional summary of the bookmark.
  * @param {string} params.userId - UUID of the user creating the bookmark (must be provided).
- * @param {string?} [params.originalUrl] - The originally submitted URL prior to normalization, if it differs
- * @param {boolean} [params.meta=false] - Metadata flag for the bookmark, defaults to false.
- * @param {Array<string>} [params.tags] - List of tags to associate with the bookmark.
+ * @param {string | null | undefined} [params.originalUrl] - The originally submitted URL prior to normalization, if it differs
+ * @param {boolean | undefined} [params.meta=false] - Metadata flag for the bookmark, defaults to false.
+ * @param {Array<string> | undefined} [params.tags] - List of tags to associate with the bookmark.
  * @throws {Error} Throws an error if userId is not provided.
  * @returns {Promise<CreatedBookmark>} The created bookmark object.
  */

--- a/packages/web/routes/api/bookmarks/put-bookmarks.js
+++ b/packages/web/routes/api/bookmarks/put-bookmarks.js
@@ -146,7 +146,7 @@ export async function putBookmarks (fastify, _opts) {
 
         // This will be the one possibly slow step
         // This needs to happen on create for de-dupe behavior
-        const workingUrl = shouldNormalize ? await normalizeURL(submittedUrl, { cache: fastify.cache }) : submittedUrl
+        const workingUrl = shouldNormalize ? await normalizeURL(submittedUrl, { cache: fastify.cache, logger: request.log }) : submittedUrl
         const workingUrlString = shouldNormalize ? workingUrl.toString() : submittedUrlString
 
         const maybeResult = await getBookmark({

--- a/packages/web/routes/api/user/auth-tokens/_jti/get-auth-token.test.js
+++ b/packages/web/routes/api/user/auth-tokens/_jti/get-auth-token.test.js
@@ -40,7 +40,7 @@ await suite('get specific auth token', async () => {
       assert.strictEqual(getRes.statusCode, 200, 'Should return 200 OK')
       const getBody = JSON.parse(getRes.payload)
       assert.strictEqual(getBody.jti, tokenJti, 'Should return the requested token')
-      assertTokenShape(assert, getBody)
+      assertTokenShape(getBody)
     })
 
     await t.test('correctly identifies current token with is_current: true', async (t) => {

--- a/packages/web/routes/api/user/auth-tokens/auth-tokens-test-utils.js
+++ b/packages/web/routes/api/user/auth-tokens/auth-tokens-test-utils.js
@@ -1,8 +1,25 @@
 import { randomUUID } from 'node:crypto'
+import * as assert from 'node:assert'
 import SQL from '@nearform/sql'
 
 /**
  * @import { AuthTokenSource } from './schemas/auth-token-base.js'
+ * @typedef {object} TestToken
+ * @property {unknown} jti
+ * @property {unknown} created_at
+ * @property {unknown} last_seen
+ * @property {unknown} last_seen_micros
+ * @property {unknown} updated_at
+ * @property {unknown} is_current
+ * @property {unknown} protect
+ * @property {unknown} user_agent
+ * @property {unknown} ip
+ * @property {unknown} note
+ * @typedef {object} TestPagination
+ * @property {unknown} top
+ * @property {unknown} bottom
+ * @property {unknown} before
+ * @property {unknown} after
  */
 
 /**
@@ -39,8 +56,7 @@ export async function createTestUser (app, t) {
   }
 
   if (registerRes.statusCode !== 201) {
-    console.error('Registration failed:', registerRes.statusCode, registerRes.payload)
-    throw new Error(`Registration failed with status ${registerRes.statusCode}`)
+    throw new Error(`Registration failed with status ${registerRes.statusCode}: ${registerRes.payload}`)
   }
 
   const registerBody = JSON.parse(registerRes.payload)
@@ -129,12 +145,10 @@ export async function createTokensWithDates (app, userId, tokenSpecs) {
 
 /**
  * Asserts that a token object has the expected shape
- * @param {import('node:assert')} assert
- * @param {any} token
- * @param {object} options
- * @param {boolean} [options.checkCurrent]
+ * @param {TestToken} token
+ * @param {{checkCurrent?: boolean | undefined}} options
  */
-export function assertTokenShape (assert, token, options = {}) {
+export function assertTokenShape (token, options = {}) {
   assert.ok(token.jti, 'Token should have JTI')
   assert.ok(token.created_at, 'Token should have created_at')
   assert.ok(token.last_seen, 'Token should have last_seen')
@@ -155,10 +169,9 @@ export function assertTokenShape (assert, token, options = {}) {
 
 /**
  * Asserts that pagination metadata has the expected shape
- * @param {import('node:assert')} assert
- * @param {any} pagination
+ * @param {TestPagination} pagination
  */
-export function assertPaginationShape (assert, pagination) {
+export function assertPaginationShape (pagination) {
   assert.strictEqual(typeof pagination.top, 'boolean', 'Pagination should have top boolean')
   assert.strictEqual(typeof pagination.bottom, 'boolean', 'Pagination should have bottom boolean')
   assert.ok('before' in pagination, 'Pagination should have before field')

--- a/packages/web/routes/api/user/auth-tokens/create-auth-token.test.js
+++ b/packages/web/routes/api/user/auth-tokens/create-auth-token.test.js
@@ -36,7 +36,7 @@ await suite('create auth token', async () => {
 
       // Check auth token details
       const authToken = createBody.auth_token
-      assertTokenShape(assert, authToken, { checkCurrent: false })
+      assertTokenShape(authToken, { checkCurrent: false })
       assert.strictEqual(authToken.note, 'My work laptop', 'Should have correct note')
       assert.strictEqual(authToken.protect, true, 'Should have correct protect status')
       assert.strictEqual(authToken.is_current, false, 'New token should not be current')
@@ -64,7 +64,7 @@ await suite('create auth token', async () => {
 
       // Check auth token details
       const authToken = createBody.auth_token
-      assertTokenShape(assert, authToken, { checkCurrent: false })
+      assertTokenShape(authToken, { checkCurrent: false })
       assert.strictEqual(authToken.note, null, 'Should have null note when not provided')
       assert.strictEqual(authToken.protect, false, 'Should have false protect when not provided')
       assert.strictEqual(authToken.is_current, false, 'New token should not be current')

--- a/packages/web/routes/api/user/auth-tokens/list-auth-tokens.test.js
+++ b/packages/web/routes/api/user/auth-tokens/list-auth-tokens.test.js
@@ -68,7 +68,7 @@ await suite('list auth tokens', async () => {
       assert.strictEqual(listBody.data.length, 1, 'Should have exactly one token')
 
       assert.ok(listBody.pagination, 'Should have pagination metadata')
-      assertPaginationShape(assert, listBody.pagination)
+      assertPaginationShape(listBody.pagination)
     })
 
     await t.test('marks current token with is_current: true', async (t) => {
@@ -86,7 +86,7 @@ await suite('list auth tokens', async () => {
       const listBody = JSON.parse(listRes.payload)
       const currentToken = listBody.data[0]
 
-      assertTokenShape(assert, currentToken, { checkCurrent: true })
+      assertTokenShape(currentToken, { checkCurrent: true })
     })
 
     await t.test('returns proper token fields', async (t) => {
@@ -104,7 +104,7 @@ await suite('list auth tokens', async () => {
       const listBody = JSON.parse(listRes.payload)
       const token = listBody.data[0]
 
-      assertTokenShape(assert, token)
+      assertTokenShape(token)
 
       // Check date formats
       assert.ok(new Date(token.created_at).getTime() > 0, 'created_at should be valid date')

--- a/packages/worker/otel.js
+++ b/packages/worker/otel.js
@@ -6,6 +6,7 @@ import { FastifyOtelInstrumentation } from '@fastify/otel'
 import { RuntimeNodeInstrumentation } from '@opentelemetry/instrumentation-runtime-node'
 import { HostMetrics } from '@opentelemetry/host-metrics'
 import { metrics } from '@opentelemetry/api'
+import { setOtelSdk } from '@breadcrum/resources/fastify-common/otel-shutdown.js'
 
 const sentryDsn = process.env['SENTRY_DSN']
 const sentryEnvironment = process.env['SENTRY_ENVIRONMENT'] ?? process.env['ENV'] ?? process.env['NODE_ENV']
@@ -51,14 +52,6 @@ export const sdk = new NodeSDK({
 })
 
 sdk.start()
+setOtelSdk(sdk)
 // Must come after sdk.start() for getMeterProvider to return something
 new HostMetrics({ meterProvider: metrics.getMeterProvider() }).start()
-
-process.on('SIGTERM', () => {
-  sdk
-    .shutdown()
-    .then(
-      () => console.log('SDK shut down successfully'),
-      (err) => console.log(new Error('Error shutting down SDK', { cause: err }))
-    )
-})

--- a/packages/worker/plugins/otel-shutdown.js
+++ b/packages/worker/plugins/otel-shutdown.js
@@ -1,0 +1,8 @@
+import fp from 'fastify-plugin'
+import { registerOtelShutdown } from '@breadcrum/resources/fastify-common/otel-shutdown.js'
+
+export default fp(async function otelShutdown (fastify) {
+  registerOtelShutdown(fastify)
+}, {
+  name: 'otel-shutdown',
+})

--- a/packages/worker/workers/bookmarks/index.js
+++ b/packages/worker/workers/bookmarks/index.js
@@ -277,7 +277,7 @@ export function makeBookmarkPgBossP ({ fastify }) {
               oembedResolved: oembed !== null,
               oembedProvider: oembed?.provider_name ?? null,
               oembedType: oembed?.type ?? null,
-            }, 'resolved episode embed')
+            }, 'episode embed resolution result')
 
             await finalizeEpisode({
               pg,

--- a/packages/worker/workers/bookmarks/index.js
+++ b/packages/worker/workers/bookmarks/index.js
@@ -273,7 +273,11 @@ export function makeBookmarkPgBossP ({ fastify }) {
               log.warn(err, 'Failed to resolve embed for episode')
             }
 
-            console.dir({ oembed })
+            log.debug({
+              oembedResolved: oembed !== null,
+              oembedProvider: oembed?.provider_name ?? null,
+              oembedType: oembed?.type ?? null,
+            }, 'resolved episode embed')
 
             await finalizeEpisode({
               pg,


### PR DESCRIPTION
## Summary

- Replace a leftover console.dir call in the bookmark worker with the job-scoped Pino logger.
- Log only bounded embed resolution metadata and avoid emitting embed HTML.
- Pass request.log through URL normalization for correlated SSRF validation warnings.
- Move OpenTelemetry shutdown into Fastify onClose hooks so shutdown success and errors use fastify.log.
- Remove redundant console output from test helpers while retaining failure payloads in thrown errors.

## Audit result

No console calls remain in Breadcrum resources or production Fastify request paths.

Browser code and standalone development scripts retain console output because they do not run within Fastify.

## Testing

- pnpm --filter @breadcrum/worker test
- pnpm --filter @breadcrum/resources test
- pnpm --filter @breadcrum/web test
- Focused web and worker ESLint and TypeScript checks after lifecycle changes